### PR TITLE
Fix for an installation error when running ./install under mac os bash shell

### DIFF
--- a/install
+++ b/install
@@ -43,8 +43,7 @@ else
     fi
 fi
 
-dir=$(dirname "${0}")
-basedir=$dir
+basedir=$(dirname "${0}")
 ${ECHOX} "I assume that CQ UNIX toolkit are in: '${basedir}'\n"
 if [ ! -d "${INSTALL_DIR}" ] 
 then


### PR DESCRIPTION
Attempting to fix an issue with the install script to make it portable on mac os by replacing the readlink with a dirname command to obtain the directory where the scripts are located prior to the install process
