### PR TITLE
Misleading redirect to stderr removed after successful package upload

### DIFF
--- a/cqput
+++ b/cqput
@@ -114,7 +114,7 @@ do
             bad=1
         else
             echo "${STATUS}"
-            echo "OK" >&2
+            echo "OK"
         fi
     fi
     shift


### PR DESCRIPTION
Currently `cqput` command outputs `OK` message to stderr after successful package upload, which is totally wrong. stderr descriptor should stay empty if exit code is 0.

Problem described here was sort of a blocker to me, as I've been doing validation after `cqput` execution that takes into consideration not only exit codes but also presence of content in stderr descriptor. In the end CRX package was successfully uploaded, but my ruby script exits with **error** message `OK` every single time I run it.
